### PR TITLE
Fix mobile navigation overlay height on small screens

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -82,7 +82,7 @@ export function Navbar() {
       {/* Mobile Navigation */}
       <div
         className={cn(
-          "md:hidden fixed inset-0 z-50 flex flex-col overflow-hidden bg-gradient-to-b from-[#1F3A33]/95 via-[#243F38]/98 to-[#1F3A33]/95 backdrop-blur-xl transition-all duration-300 ease-out",
+          "md:hidden fixed inset-x-0 top-0 z-50 flex min-h-dvh flex-col overflow-hidden bg-gradient-to-b from-[#1F3A33]/95 via-[#243F38]/98 to-[#1F3A33]/95 backdrop-blur-xl transition-all duration-300 ease-out",
           isMenuOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",
         )}
       >


### PR DESCRIPTION
## Summary
- ensure the mobile navigation overlay stretches the full viewport height so the menu content is visible on phones
- keep the animated gradient backdrop and pointer-event toggling intact while improving Safari/mobile compatibility

## Testing
- Manually verified the mobile menu renders full height in the browser

------
https://chatgpt.com/codex/tasks/task_e_68f054fe4814832e955f4e4ed2bb7a2f