### PR TITLE
Fix dark mode toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,11 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
+}
+
+.dark {
+  color-scheme: dark;
 }
 
 * {
@@ -25,17 +29,10 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    --retro-link-contrast: #000000;
-    background-color: #000000;
-    color: #ffffff;
-  }
-
-  .profile-card {
-    background-color: #000000;
-    box-shadow: 0 0 0 4px #ffffff inset;
-  }
+.dark body {
+  --retro-link-contrast: #000000;
+  background-color: #000000;
+  color: #ffffff;
 }
 
 .retro-main {
@@ -49,6 +46,11 @@ body {
   text-align: center;
   background-color: #ffffff;
   transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.dark .profile-card {
+  background-color: #000000;
+  box-shadow: 0 0 0 4px #ffffff inset;
 }
 
 .profile-card:hover {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import type { ReactNode } from "react"
 import { Press_Start_2P } from "next/font/google"
 import "./globals.css"
+import { ThemeProvider } from "@/components/theme-provider"
 
 const retro = Press_Start_2P({
   weight: "400",
@@ -17,9 +18,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      <body className={`${retro.className}`}>
-        {children}
+    <html lang="en" suppressHydrationWarning>
+      <body className={retro.className}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- wrap the app shell in the next-themes `ThemeProvider` so the theme toggle can control the document class
- update the global styles to respond to the `.dark` class instead of `prefers-color-scheme`

## Testing
- not run (lint command requires interactive setup)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691deb6610ec832e84f1248767d67fc4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to class-based dark mode using next-themes ThemeProvider and updates global styles to respond to `.dark`.
> 
> - **App Shell**:
>   - Wraps content with `ThemeProvider` in `app/layout.tsx` (`attribute="class"`, `defaultTheme="system"`, `enableSystem`, `disableTransitionOnChange`), and adds `suppressHydrationWarning` on `<html>`.
> - **Styles**:
>   - Updates `app/globals.css` to use `.dark` class instead of `prefers-color-scheme` media query.
>   - Sets `:root { color-scheme: light }` and `.dark { color-scheme: dark }`.
>   - Moves dark-mode overrides to `.dark body` and `.dark .profile-card`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e58b4af51570e784b8d1fcef4adc46ba46a99a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->