### PR TITLE
Improve SEO, accessibility, correctness, and developer experience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Required for the AI chat + job-fit endpoints
+# Without it, /chat UI renders but API calls fail
+OPENAI_API_KEY=
+
+# Optional: Neon/Postgres connection string for AI interaction analytics
+# The ai_interactions table is auto-created on first write.
+# Run spec/ai-interactions-schema.sql manually for a clean setup.
+DATABASE_URL=
+
+# Optional: override used by the local-dashboard app
+# DASHBOARD_DATABASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,13 @@ dist
 .env.local
 local-dashboard/
 
+# Claude Code / opencode local config
+.claude/
+.opencode/
+
+# Personal reference files (not part of the site)
+spec/Profile-1.pdf
+
 # Playwright artifacts
 playwright-report/
 test-results/

--- a/README.md
+++ b/README.md
@@ -234,13 +234,16 @@ Model IDs are configured in the route files (`app/api/chat/route.ts`, `app/api/j
 
 ## Testing
 
-- **Vitest** — `lib/ai/validation.test.ts` (input validation + injection detection).
+- **Vitest** — `lib/ai/validation.test.ts` (input validation + injection detection),
+  `lib/utils.test.ts` (slugify, date formatting, cn).
 - **Playwright** (`e2e/`):
   - `smoke.spec.ts` — every route renders, terminal nav/footer present, **zero legacy
     Persona-era classes**, no console errors.
   - `seo.spec.ts` — `/job-fit` 308 redirect, og:image works, sitemap/robots/rss/llms-full.txt.
   - `chat.spec.ts` — chat + JD-mode interactions with `/api/chat` and `/api/job-fit` mocked
     via `page.route` (no live OpenAI calls).
+  - `interactions.spec.ts` — command palette (⌘K, fuzzy-find, shell commands, easter eggs),
+    blog j/k keyboard navigation, 404 page.
 
 ---
 
@@ -292,8 +295,8 @@ e2e/                      # Playwright specs (smoke, seo, chat)
 - **Use `term-*` tokens** for all colors and the shared terminal components for new UI.
 - **postcss override.** `package.json` overrides Next's bundled `postcss` to `^8.5.10` to clear a
   stringify-XSS advisory (Next pins `8.4.31`). Keep this until Next ships a newer postcss.
-- `next.config.mjs` sets `typescript.ignoreBuildErrors` — run `npx tsc --noEmit` to typecheck;
-  `next build` alone won't catch type errors.
+- `next build` enforces both TypeScript and ESLint — type errors or lint errors will fail
+  the build. Run `npx tsc --noEmit` and `npm run lint` locally before pushing.
 
 ## Deployment
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,12 @@
     @apply bg-term-bg text-term-fg;
   }
 
+  /* Visible keyboard focus indicator across the whole site. */
+  :focus-visible {
+    outline: 2px solid theme("colors.term.accent");
+    outline-offset: 2px;
+  }
+
   /* Text selection in the accent red — small, everywhere, unmistakably ours. */
   ::selection {
     background: #ef4444; /* term-accent */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,14 +23,46 @@ export const metadata: Metadata = {
   },
   description:
     "Personal website and blog of Brian Best — Principal Software Developer building agentic AI, MCP integrations, and production LLM systems.",
+  authors: [{ name: "Brian Best", url: "https://brianbest.com" }],
+  creator: "Brian Best",
+  publisher: "Brian Best",
+  keywords: [
+    "Brian Best",
+    "Principal Software Developer",
+    "Agentic AI",
+    "LLM",
+    "MCP",
+    "Model Context Protocol",
+    "AI engineering",
+    "TypeScript",
+    "Next.js",
+  ],
+  alternates: {
+    canonical: "/",
+    types: {
+      "application/rss+xml": [{ url: "/rss.xml", title: "RSS Feed" }],
+    },
+  },
   openGraph: {
     type: "website",
     siteName: "Brian Best",
     locale: "en_US",
+    url: "https://brianbest.com",
   },
   twitter: {
     card: "summary_large_image",
+    creator: "@brianbest",
+    site: "@brianbest",
   },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+export const viewport = {
+  themeColor: "#0f0d0c",
+  colorScheme: "dark",
 }
 
 export default function RootLayout({

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,4 +1,5 @@
 import { getPost, getPosts } from "@/lib/posts"
+import { getProjects } from "@/lib/projects"
 import { getPublicProfileAsText } from "@/lib/career-profile"
 
 const BASE_URL = "https://brianbest.com"
@@ -7,15 +8,32 @@ const BASE_URL = "https://brianbest.com"
 export const dynamic = "force-static"
 
 // llms-full.txt — the whole site as one plain-text document for LLM readers:
-// career profile plus every blog post's raw markdown.
+// career profile, projects, and every blog post's raw markdown.
 export async function GET() {
-  const metas = await getPosts()
+  const [metas, projects] = await Promise.all([getPosts(), getProjects()])
   const posts = await Promise.all(metas.map((m) => getPost(m.slug)))
+
+  const projectsText = projects
+    .map(
+      (project) => `===
+
+# Project: ${project.title}
+
+URL: ${project.url || `${BASE_URL}/projects`}
+${project.url ? `External: ${project.url}` : "Local / private"}
+Tags: ${project.tags.join(", ")}
+Featured: ${project.featured ? "yes" : "no"}
+
+${project.description}
+
+${project.content?.trim() ?? ""}`,
+    )
+    .join("\n\n")
 
   const postsText = posts
     .filter((p): p is NonNullable<typeof p> => p !== null)
     .map(
-      (post) => `----
+      (post) => `===
 
 # ${post.title}
 
@@ -31,10 +49,16 @@ ${post.content.trim()}`,
   const body = `# brianbest.com — full site content for LLMs
 
 This file contains the complete content of Brian Best's personal site in plain text:
-his career profile followed by every blog post in full. Canonical URLs are included.
+his career profile, his projects, and every blog post in full. Canonical URLs are included.
 For interactive questions, his AI assistant lives at ${BASE_URL}/chat.
 
 ${getPublicProfileAsText().trim()}
+
+# Projects
+
+${projectsText}
+
+# Blog Posts
 
 ${postsText}
 `

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -16,6 +16,7 @@ function escapeXml(text: string): string {
 
 export async function GET() {
   const posts = await getPosts()
+  const lastBuildDate = posts[0] ? new Date(posts[0].date).toUTCString() : new Date().toUTCString()
 
   const items = posts
     .map(
@@ -24,6 +25,7 @@ export async function GET() {
       <link>${BASE_URL}/blog/${post.slug}</link>
       <guid isPermaLink="true">${BASE_URL}/blog/${post.slug}</guid>
       <description>${escapeXml(post.summary)}</description>
+      <author>brian.best.contact@pm.me (Brian Best)</author>
       <pubDate>${new Date(post.date).toUTCString()}</pubDate>
       ${post.tags.map((t) => `<category>${escapeXml(t)}</category>`).join("\n      ")}
     </item>`,
@@ -37,6 +39,8 @@ export async function GET() {
     <link>${BASE_URL}/blog</link>
     <description>Working notes on building with LLMs — patterns, harnesses, evals, the parts nobody puts in the demo.</description>
     <language>en-us</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <ttl>60</ttl>
     <atom:link href="${BASE_URL}/rss.xml" rel="self" type="application/rss+xml" />
 ${items}
   </channel>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,17 +8,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const newestPostDate = posts[0] ? new Date(posts[0].date) : new Date()
 
   const staticRoutes: MetadataRoute.Sitemap = [
-    { url: `${BASE_URL}/`, lastModified: newestPostDate, priority: 1 },
-    { url: `${BASE_URL}/blog`, lastModified: newestPostDate, priority: 0.9 },
-    { url: `${BASE_URL}/about`, priority: 0.8 },
-    { url: `${BASE_URL}/projects`, priority: 0.8 },
-    { url: `${BASE_URL}/chat`, priority: 0.7 },
-    { url: `${BASE_URL}/contact`, priority: 0.6 },
+    { url: `${BASE_URL}/`, lastModified: newestPostDate, changeFrequency: "weekly", priority: 1 },
+    { url: `${BASE_URL}/blog`, lastModified: newestPostDate, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE_URL}/about`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
+    { url: `${BASE_URL}/projects`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
+    { url: `${BASE_URL}/chat`, lastModified: new Date(), changeFrequency: "yearly", priority: 0.7 },
+    { url: `${BASE_URL}/contact`, lastModified: new Date(), changeFrequency: "yearly", priority: 0.6 },
   ]
 
   const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${BASE_URL}/blog/${post.slug}`,
     lastModified: new Date(post.date),
+    changeFrequency: "monthly" as const,
     priority: 0.7,
   }))
 

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -26,8 +26,14 @@ export default async function Layout({ children }: { children: React.ReactNode }
 
   return (
     <div className="flex flex-col min-h-screen">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-term-accent focus:text-term-bg focus:font-mono focus:text-sm"
+      >
+        Skip to content
+      </a>
       <TerminalNav postCount={posts.length} />
-      <div className="flex-grow">{children}</div>
+      <div id="main-content" className="flex-grow">{children}</div>
       <TerminalFooter />
       <CommandPalette items={paletteItems} />
     </div>

--- a/components/terminal/code-block.tsx
+++ b/components/terminal/code-block.tsx
@@ -63,6 +63,7 @@ export function CodeBlock({
             onClick={handleCopy}
             className="hover:text-term-fg transition-colors cursor-pointer"
             type="button"
+            aria-label={copied ? "Code copied to clipboard" : "Copy code to clipboard"}
           >
             {copied ? "copied!" : "copy"}
           </button>
@@ -91,7 +92,8 @@ export function CodeBlock({
           </div>
         )}
         <pre
-          className="m-0 flex-1 leading-[1.65] overflow-x-auto text-[13px]"
+          className="m-0 flex-1 leading-[1.65] overflow-x-auto text-[13px] focus:outline-none"
+          tabIndex={0}
           style={{ padding: showLineNumbers ? "18px 24px" : "18px 24px" }}
         >
           {highlight(code, "dark")}

--- a/components/terminal/nav.tsx
+++ b/components/terminal/nav.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { track } from "@vercel/analytics"
@@ -85,6 +85,15 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
   const pathname = usePathname()
   const resolvedActive = active ?? deriveActive(pathname)
 
+  useEffect(() => {
+    if (!mobileOpen) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileOpen(false)
+    }
+    document.addEventListener("keydown", handleEscape)
+    return () => document.removeEventListener("keydown", handleEscape)
+  }, [mobileOpen])
+
   const handleNavClick = (label: string, href: string) => {
     track("cta_click", { location: "nav", label, destination: href })
     setMobileOpen(false)
@@ -93,7 +102,7 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
   return (
     <>
       {/* ── Desktop nav (md+) ── */}
-      <nav className="hidden md:flex bg-term-bg-2 border-b border-term-rule items-stretch pl-4">
+      <nav aria-label="Primary" className="hidden md:flex bg-term-bg-2 border-b border-term-rule items-stretch pl-4">
         {/* Monogram + brand */}
         <div className="flex items-center gap-3 px-6 border-r border-term-rule">
           <Link
@@ -101,7 +110,7 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
             onClick={() => handleNavClick("brand", "/")}
             className="flex items-center gap-3 no-underline"
           >
-            <div className="w-8 h-8 bg-term-accent text-term-bg font-mono font-bold text-[15px] grid place-items-center flex-shrink-0">
+            <div className="w-8 h-8 bg-term-accent text-term-bg font-mono font-bold text-[15px] grid place-items-center flex-shrink-0" aria-hidden="true">
               $
             </div>
             <span className="font-mono font-semibold text-term-fg text-[14px]">brianbest.com</span>
@@ -140,7 +149,7 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
           onClick={() => handleNavClick("chat", "/chat")}
           className="flex items-center gap-2 px-[18px] font-mono text-[13px] text-term-fg hover:text-term-accent transition-colors no-underline"
         >
-          <span className="w-[7px] h-[7px] bg-term-accent rounded-full pulse-soft" />
+          <span className="w-[7px] h-[7px] bg-term-accent rounded-full pulse-soft" aria-hidden="true" />
           <span>Chat with Brian&rsquo;s AI</span>
           <span className="ml-2 px-2 py-0.5 bg-term-accent text-term-bg text-[10px] font-bold tracking-[0.06em]">
             LIVE
@@ -149,11 +158,11 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
       </nav>
 
       {/* ── Mobile nav (< md) ── */}
-      <nav className="md:hidden bg-term-bg-2 border-b border-term-rule px-[14px] h-[52px] flex items-center justify-between gap-[10px]">
+      <nav aria-label="Primary" className="md:hidden bg-term-bg-2 border-b border-term-rule px-[14px] h-[52px] flex items-center justify-between gap-[10px]">
         {/* Left: monogram + brand */}
         <div className="flex items-center gap-[10px]">
           <Link href="/" onClick={() => handleNavClick("brand", "/")} className="flex items-center gap-[10px]">
-            <div className="w-7 h-7 bg-term-accent text-term-bg font-mono font-bold text-[14px] grid place-items-center">
+            <div className="w-7 h-7 bg-term-accent text-term-bg font-mono font-bold text-[14px] grid place-items-center" aria-hidden="true">
               $
             </div>
             <span className="font-mono font-semibold text-term-fg text-[13px]">brianbest.com</span>
@@ -167,7 +176,7 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
             onClick={() => handleNavClick("chat", "/chat")}
             className="inline-flex items-center gap-[6px] px-[11px] py-[7px] bg-term-accent text-term-bg font-mono text-[12px] font-semibold no-underline glow-accent"
           >
-            <span className="w-[5px] h-[5px] bg-term-bg rounded-full pulse-soft" />
+            <span className="w-[5px] h-[5px] bg-term-bg rounded-full pulse-soft" aria-hidden="true" />
             Chat with Brian&rsquo;s AI
           </Link>
 
@@ -176,6 +185,8 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
             type="button"
             onClick={() => setMobileOpen(true)}
             aria-label="Open menu"
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-menu"
             className="flex flex-col gap-[4px] p-[10px_4px] cursor-pointer"
           >
             <span className="block w-[18px] h-[1.5px] bg-term-fg" />
@@ -186,11 +197,11 @@ export function TerminalNav({ active, postCount = 4 }: TerminalNavProps) {
 
       {/* ── Mobile full-screen menu overlay ── */}
       {mobileOpen && (
-        <div className="md:hidden fixed inset-0 z-50 bg-term-bg flex flex-col">
+        <div id="mobile-menu" className="md:hidden fixed inset-0 z-50 bg-term-bg flex flex-col">
           {/* Header */}
           <div className="px-[14px] h-[52px] flex items-center justify-between border-b border-term-rule bg-term-bg-2">
             <Link href="/" onClick={() => handleNavClick("brand", "/")} className="flex items-center gap-[10px]">
-              <div className="w-7 h-7 bg-term-accent text-term-bg font-mono font-bold text-[14px] grid place-items-center">
+              <div className="w-7 h-7 bg-term-accent text-term-bg font-mono font-bold text-[14px] grid place-items-center" aria-hidden="true">
                 $
               </div>
               <span className="font-mono font-semibold text-term-fg text-[13px]">brianbest.com</span>

--- a/components/terminal/prompt.tsx
+++ b/components/terminal/prompt.tsx
@@ -21,7 +21,7 @@ export function Prompt({ kind = "$", children }: PromptProps) {
 
   return (
     <div className="flex gap-[10px] font-mono text-term-fg-soft text-sm leading-[1.6]">
-      <span className={`${sigil} select-none`}>{kind}</span>
+      <span className={`${sigil} select-none`} aria-hidden="true">{kind}</span>
       <span>{children}</span>
     </div>
   )

--- a/content/blog/2026-05-writing-for-agent-readers.md
+++ b/content/blog/2026-05-writing-for-agent-readers.md
@@ -37,5 +37,5 @@ The two goals don't conflict. **Structure is for the agent; voice is for the hum
 ## The bet
 
 - The median reader of technical content is shifting from human to agent, and that changes what "well-written" means in practice.
-- The fix is structural, not stylistic: front-loaded theses, descriptive headings, disciplined bolding, backticked identifiers, self-contained code, extractable takeaways.
+- The fix is structural, not stylistic: front-load theses, descriptive headings, disciplined bolding, backticked identifiers, self-contained code, extractable takeaways.
 - Writing for agents and writing for humans converge — both reward putting the point where it can be found. If you have to choose, optimize for the reader that decides whether anyone else ever sees your post.

--- a/lib/ai/interaction-store.ts
+++ b/lib/ai/interaction-store.ts
@@ -115,6 +115,8 @@ async function ensureSchema(): Promise<void> {
         ON ai_interactions (endpoint)
       `
     } catch (error) {
+      // Reset so a transient failure doesn't permanently block persistence
+      schemaReadyPromise = null
       logPersistenceIssue({
         event: "schema_failed",
         endpoint: "chat",

--- a/lib/ai/system-prompt.ts
+++ b/lib/ai/system-prompt.ts
@@ -3,8 +3,8 @@ import { getProfileAsText, getPublicProfileAsText, careerProfile } from "@/lib/c
 export function getChatSystemPrompt(): string {
   const profileText = getPublicProfileAsText()
 
-  return `You are an AI assistant representing ${careerProfile.personal.name}, a ${careerProfile.personal.title}.
-Your role is to answer questions about ${careerProfile.personal.name}'s professional background, skills, experience, and career goals.
+  return `You are ${careerProfile.personal.name}'s AI assistant, answering questions about ${careerProfile.personal.name}'s professional background, skills, experience, and career goals on his behalf.
+You speak in first person as Brian ("I", "my", "me") when discussing his experience, because you are representing him directly.
 
 ## SECURITY RULES (HIGHEST PRIORITY)
 
@@ -81,7 +81,7 @@ ${profileText}
 
 - **Off-topic requests**: "I'm here specifically to help you learn about Brian's professional background and experience. What would you like to know about his skills or career?"
 
-Remember: Your purpose is to give hiring managers an authentic, in-depth view of this candidate that they couldn't get from a traditional resume. Always stay in character as Brian's professional representative.`
+Remember: Your purpose is to give hiring managers an authentic, in-depth view of this candidate that they couldn't get from a traditional resume. Stay in character as Brian speaking about himself.`
 }
 
 export function getJobFitSystemPrompt(): string {

--- a/lib/ai/validation.test.ts
+++ b/lib/ai/validation.test.ts
@@ -95,6 +95,25 @@ describe("sanitizeInput", () => {
     const result = sanitizeInput(longString, 4500)
     expect(result.length).toBe(4500)
   })
+
+  it("strips zero-width characters", () => {
+    expect(sanitizeInput("hello\u200Bworld")).toBe("helloworld")
+    expect(sanitizeInput("hello\u200Cworld")).toBe("helloworld")
+    expect(sanitizeInput("hello\u200Dworld")).toBe("helloworld")
+    expect(sanitizeInput("hello\uFEFFworld")).toBe("helloworld")
+  })
+
+  it("strips bidi control characters", () => {
+    expect(sanitizeInput("hello\u202Eworld")).toBe("helloworld")
+    expect(sanitizeInput("\u2066hello\u2069")).toBe("hello")
+  })
+
+  it("strips C0/C1 control characters except tab/newline", () => {
+    expect(sanitizeInput("hello\x07world")).toBe("helloworld")
+    expect(sanitizeInput("hello\x1Fworld")).toBe("helloworld")
+    expect(sanitizeInput("hello\tworld")).toBe("hello\tworld")
+    expect(sanitizeInput("hello\nworld")).toBe("hello\nworld")
+  })
 })
 
 describe("validateChatInput", () => {

--- a/lib/ai/validation.ts
+++ b/lib/ai/validation.ts
@@ -205,6 +205,12 @@ export function sanitizeInput(input: string, maxLength: number = 4000): string {
   // Remove null bytes
   let sanitized = input.replace(/\0/g, "")
 
+  // Remove zero-width and other invisible characters that can bypass injection detection
+  sanitized = sanitized.replace(/[\u200B\u200C\u200D\uFEFF\u200E\u200F\u202A-\u202E\u2066-\u2069]/g, "")
+
+  // Strip remaining C0/C1 control characters (except tab, newline, carriage return)
+  sanitized = sanitized.replace(/[\x01-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, "")
+
   // Remove excessive whitespace
   sanitized = sanitized.replace(/\s{10,}/g, " ")
 

--- a/lib/career-profile.ts
+++ b/lib/career-profile.ts
@@ -106,15 +106,15 @@ export const careerProfile: CareerProfile = {
     title: "Principal Software Developer",
     location: "Kitchener, Ontario, Canada",
     email: "brian.best.contact@pm.me",
-    linkedin: "linkedin.com/in/brianbest101",
-    github: "github.com/brianbest",
-    website: "brianbest.com",
+    linkedin: "https://linkedin.com/in/brianbest101",
+    github: "https://github.com/brianbest",
+    website: "https://brianbest.com",
     summary: `Principal Software Developer at Axonify with 12+ years of full-stack engineering experience and 3+ years architecting production AI systems —
 agentic AI, LLM-powered applications, multi-agent orchestration, and Model Context Protocol (MCP) integrations. Currently co-leads an internal agentic AI
 "code factory" and drives LLM-powered capabilities into the customer-facing Axonify platform, spanning RAG and retrieval pipelines, secure tool-calling for
 AI agents, and conversational interfaces that operate within enterprise compliance boundaries. Advanced from Software Developer to Principal in six years.
 Former startup co-founder (raised CAD $75k, Propel ICT accelerator) with a non-traditional path from radio broadcasting into AI/LLM engineering.`,
-    tagline: "Agentic engineering - Building the system that builds the system",
+    tagline: "Agentic engineering — Building the system that builds the system",
   },
 
   personality: {
@@ -123,7 +123,7 @@ Former startup co-founder (raised CAD $75k, Propel ICT accelerator) with a non-t
       "Comfortable presenting to diverse audiences from technical teams to executives",
       "Skilled at translating complex technical concepts into accessible explanations",
       "Experience with live, unscripted communication under pressure",
-      "Has proven experince in effective communication that other engineers struggle with"
+      "Has proven experience in effective communication that other engineers struggle with"
     ],
     workingStyle: [
       "Collaborative problem solver who values diverse perspectives",
@@ -160,7 +160,7 @@ Former startup co-founder (raised CAD $75k, Propel ICT accelerator) with a non-t
   ],
 
   currentFocus: {
-    tagline: "Agentic engineering - Building the system that builds the system",
+    tagline: "Agentic engineering — Building the system that builds the system",
     areas: [
       "Co-leading an internal agentic AI development platform — an in-house \"code factory\" of LLM-powered coding agents",
       "Productizing LLM capabilities into customer-facing enterprise features",
@@ -532,10 +532,10 @@ ${p.education.map((edu) => `- ${edu.degree}, ${edu.school} (${edu.year})${edu.hi
 ${p.awards.map((award) => `- ${award.name} (${award.context})`).join("\n")}
 
 ## Career Trajectory Highlights
-- **Growth at Axonify:** Software Developer -> Intermediate -> Senior -> Principal Software Developer (Mar 2020 - Present)
+- **Growth at Axonify:** Software Developer → Intermediate → Senior → Principal Software Developer (Mar 2020 - Present)
 - **Startup Experience:** Co-founded Phased.io, raised CAD $75k, completed Propel ICT accelerator
 - **Leadership at Scale:** Student Union Chairman overseeing 14,000 students and $3.1M budget
-- **Non-traditional Path:** Radio broadcasting -> Web development -> AI/LLM engineering
+- **Non-traditional Path:** Radio broadcasting → Web development → AI/LLM engineering
 `
 }
 

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,5 +1,6 @@
 import fs from "fs"
 import path from "path"
+import { cache } from "react"
 import matter from "gray-matter"
 import { slugify } from "./utils"
 
@@ -24,37 +25,48 @@ function readPostFile(filename: string): Post {
   const raw = fs.readFileSync(path.join(postsDir, filename), "utf8")
   const { data, content } = matter(raw)
 
+  if (typeof data.title !== "string" || !data.title.trim()) {
+    throw new Error(`Post "${filename}" is missing required frontmatter: title`)
+  }
+  if (typeof data.date !== "string" || !data.date.trim()) {
+    throw new Error(`Post "${filename}" is missing required frontmatter: date`)
+  }
+  if (typeof data.summary !== "string" || !data.summary.trim()) {
+    throw new Error(`Post "${filename}" is missing required frontmatter: summary`)
+  }
+
   const wordCount = content.trim().split(/\s+/).length
   const readingTime = `${Math.max(1, Math.round(wordCount / 200))} min`
 
   return {
     slug,
-    title: data.title as string,
-    date: data.date as string,
-    summary: data.summary as string,
-    tags: (data.tags as string[]) ?? [],
+    title: data.title,
+    date: data.date,
+    summary: data.summary,
+    tags: Array.isArray(data.tags) ? data.tags : [],
     content,
     wordCount,
     readingTime,
   }
 }
 
-export async function getPosts(): Promise<PostMeta[]> {
+export const getPosts = cache(async (): Promise<PostMeta[]> => {
+  if (!fs.existsSync(postsDir)) return []
   const files = fs.readdirSync(postsDir).filter((f) => f.endsWith(".md"))
   const posts = files.map((f) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { content: _, ...meta } = readPostFile(f)
     return meta
   })
-  return posts.sort((a, b) => (a.date < b.date ? 1 : -1))
-}
+  return posts.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0))
+})
 
-export async function getPost(slug: string): Promise<Post | null> {
+export const getPost = cache(async (slug: string): Promise<Post | null> => {
   const filename = `${slug}.md`
   const fullPath = path.join(postsDir, filename)
   if (!fs.existsSync(fullPath)) return null
   return readPostFile(filename)
-}
+})
 
 /**
  * getAdjacentPosts — based on date-sorted list (newest first).
@@ -63,9 +75,10 @@ export async function getPost(slug: string): Promise<Post | null> {
  * Matching the prototype's prev/next arrow semantics:
  *   ← prev (newer)     next → (older)
  */
-export async function getAdjacentPosts(
-  slug: string,
-): Promise<{ prev: PostMeta | null; next: PostMeta | null }> {
+export const getAdjacentPosts = cache(
+  async (
+    slug: string,
+  ): Promise<{ prev: PostMeta | null; next: PostMeta | null }> => {
   const posts = await getPosts() // already sorted newest → oldest
   const idx = posts.findIndex((p) => p.slug === slug)
 
@@ -77,7 +90,8 @@ export async function getAdjacentPosts(
   const next = idx < posts.length - 1 ? posts[idx + 1] : null
 
   return { prev, next }
-}
+  },
+)
 
 export type Heading = {
   id: string

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -1,5 +1,6 @@
 import fs from "fs"
 import path from "path"
+import { cache } from "react"
 import matter from "gray-matter"
 
 // Projects are markdown files in content/projects/*.md — same content model as
@@ -23,19 +24,23 @@ function readProjectFile(filename: string): Project {
   const raw = fs.readFileSync(path.join(projectsDir, filename), "utf8")
   const { data, content } = matter(raw)
 
+  if (typeof data.title !== "string" || !data.title.trim()) {
+    throw new Error(`Project "${filename}" is missing required frontmatter: title`)
+  }
+
   return {
     id,
-    title: (data.title as string) ?? id,
-    description: (data.description as string) ?? "",
-    image: (data.image as string) ?? "",
-    tags: (data.tags as string[]) ?? [],
-    url: (data.url as string) ?? "",
-    featured: (data.featured as boolean) ?? false,
+    title: data.title,
+    description: typeof data.description === "string" ? data.description : "",
+    image: typeof data.image === "string" ? data.image : "",
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    url: typeof data.url === "string" ? data.url : "",
+    featured: typeof data.featured === "boolean" ? data.featured : false,
     content,
   }
 }
 
-export async function getProjects(): Promise<Project[]> {
+export const getProjects = cache(async (): Promise<Project[]> => {
   if (!fs.existsSync(projectsDir)) return []
   const files = fs.readdirSync(projectsDir).filter((f) => f.endsWith(".md"))
   const projects = files.map(readProjectFile)
@@ -45,10 +50,10 @@ export async function getProjects(): Promise<Project[]> {
     if (a.featured !== b.featured) return a.featured ? -1 : 1
     return a.title.localeCompare(b.title)
   })
-}
+})
 
-export async function getProject(id: string): Promise<Project | null> {
+export const getProject = cache(async (id: string): Promise<Project | null> => {
   const fullPath = path.join(projectsDir, `${id}.md`)
   if (!fs.existsSync(fullPath)) return null
   return readProjectFile(`${id}.md`)
-}
+})

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import { slugify, formatDate, formatTerminalDate, cn } from "./utils"
+
+describe("slugify", () => {
+  it("lowercases text", () => {
+    expect(slugify("Hello World")).toBe("hello-world")
+  })
+
+  it("replaces spaces with hyphens", () => {
+    expect(slugify("why a separate harness")).toBe("why-a-separate-harness")
+  })
+
+  it("strips non-alphanumerics (except hyphens and spaces)", () => {
+    expect(slugify("C++ Tips & Tricks!")).toBe("c-tips-tricks")
+  })
+
+  it("collapses multiple hyphens", () => {
+    expect(slugify("foo   bar")).toBe("foo-bar")
+    expect(slugify("foo---bar")).toBe("foo-bar")
+  })
+
+  it("trims leading/trailing whitespace", () => {
+    expect(slugify("  hello  ")).toBe("hello")
+  })
+
+  it("handles empty string", () => {
+    expect(slugify("")).toBe("")
+  })
+})
+
+describe("formatDate", () => {
+  it("formats a date-only string in UTC", () => {
+    expect(formatDate("2026-05-20")).toBe("May 20, 2026")
+  })
+
+  it("formats a date at year boundary", () => {
+    expect(formatDate("2026-01-01")).toBe("January 1, 2026")
+  })
+})
+
+describe("formatTerminalDate", () => {
+  it("formats in lowercase", () => {
+    expect(formatTerminalDate("2026-05-20")).toBe("may 20, 2026")
+  })
+
+  it("returns the input string for invalid dates", () => {
+    expect(formatTerminalDate("not-a-date")).toBe("not-a-date")
+  })
+
+  it("does not shift the day in negative-offset timezones (UTC)", () => {
+    // 2026-05-20 parsed as UTC midnight; formatted in UTC → "may 20", not "may 19"
+    expect(formatTerminalDate("2026-05-20")).toBe("may 20, 2026")
+  })
+})
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("foo", "bar")).toBe("foo bar")
+  })
+
+  it("handles conditional classes", () => {
+    expect(cn("base", false && "no", true && "yes")).toBe("base yes")
+  })
+
+  it("resolves Tailwind conflicts (last wins)", () => {
+    expect(cn("p-4", "p-2")).toBe("p-2")
+  })
+})

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary

A comprehensive quality pass across the site, starting from first principles: the site is well-built but had many small issues across SEO, accessibility, correctness, content, and developer experience. This PR addresses them in focused categories.

## Changes

### Correctness fixes
- **lib/posts.ts sort bug** — the comparator `(a, b) => (a.date < b.date ? 1 : -1)` returned `-1` for equal dates, causing non-deterministic ordering for same-day posts. Fixed to a proper 3-way comparator. Also added frontmatter validation (throws clear errors for missing title/date/summary instead of silent undefined) and wrapped all data functions with React `cache()` to eliminate O(n²) filesystem reads during SSG.
- **lib/projects.ts** — same frontmatter validation and `cache()` treatment for consistency.
- **lib/ai/interaction-store.ts** — `schemaReadyPromise` was never reset on failure, so a transient DB error permanently blocked persistence until process restart. Now resets to null in the catch block.
- **lib/ai/validation.ts** — `sanitizeInput` now strips zero-width characters, bidi control characters, and C0/C1 control characters. These invisible characters could bypass injection detection regexes.

### SEO & machine-readable routes
- **app/layout.tsx** — added themeColor, colorScheme, authors, creator, publisher, keywords, robots, RSS alternates, twitter creator/site, and openGraph.url. These were all missing from the root metadata.
- **app/sitemap.ts** — added lastModified to all static routes (was only on / and /blog) and changeFrequency to every entry.
- **app/rss.xml/route.ts** — added lastBuildDate, ttl, and author to items (RSS 2.0 recommended elements).
- **app/llms-full.txt/route.ts** — added a Projects section (was missing entirely), changed the post separator from `----` (valid YAML doc separator) to `===`, and added section headers for better LLM parseability.
- **next.config.mjs** — removed eslint.ignoreDuringBuilds and typescript.ignoreBuildErrors. Both tsc --noEmit and next build pass clean, so these flags were silently allowing future type/lint errors to ship to production.

### Accessibility
- **app/globals.css** — added global :focus-visible outline (2px solid term-accent) so keyboard users always see focus.
- **components/layout.tsx** — added a skip-to-content link (sr-only, visible on focus) with id="main-content" on the content wrapper.
- **components/terminal/nav.tsx** — added aria-label="Primary" to both nav landmarks, aria-hidden on decorative monograms and pulse dots, aria-expanded/aria-controls on the hamburger button, Escape key handling for the mobile menu, and id="mobile-menu" on the overlay.
- **components/terminal/prompt.tsx** — aria-hidden on the decorative sigil.
- **components/terminal/code-block.tsx** — tabIndex on pre so long code lines are keyboard-scrollable, and aria-label on the copy button.

### Content & data fixes
- **lib/career-profile.ts** — fixed "experince" to "experience" typo, added https:// protocol to linkedin/github/website fields, and fixed arrow style inconsistency (ASCII -> to Unicode arrow) in career trajectory highlights.
- **content/blog/2026-05-writing-for-agent-readers.md** — fixed "front-loaded theses" to "front-load theses" (verb form inconsistency with other imperative bullets).
- **lib/ai/system-prompt.ts** — resolved contradictory persona framing: the prompt said both "AI assistant representing Brian" (3rd person) and "speak as if you are Brian... use first person" (1st person). Now consistently frames the assistant as speaking in first person as Brian.

### Developer experience
- **.env.example** — new file documenting OPENAI_API_KEY and DATABASE_URL.
- **.gitignore** — added .claude/, .opencode/, and spec/Profile-1.pdf to stop them showing as untracked.
- **lib/utils.test.ts** — new unit tests for slugify, formatDate, formatTerminalDate, and cn.
- **lib/ai/validation.test.ts** — added tests for zero-width, bidi, and control character stripping.
- **README.md** — added interactions.spec.ts to the testing section, removed the stale ignoreBuildErrors note.

## Verification
- `npx tsc --noEmit` — 0 errors
- `npm run lint` — 0 errors (21 pre-existing `any` warnings in mdx-content.tsx, unchanged)
- `npm run test:run` — 49 tests pass (14 new)
- `npm run build` — succeeds, all routes prerendered
